### PR TITLE
Fix compatibility problem for using absolue path in FileSets.

### DIFF
--- a/src/main/java/enix/capsule/CapsuleMojo.java
+++ b/src/main/java/enix/capsule/CapsuleMojo.java
@@ -554,7 +554,15 @@ public class CapsuleMojo extends AbstractMojo {
 
 		for (final FileSet fileSet : fileSets) {
 			if (fileSet.directory != null && !fileSet.directory.isEmpty()) {
-				final File directory = new File(baseDir.getPath() + File.separatorChar + fileSet.directory);
+				final File fileSetDir = new File(fileSet.directory);
+				final File directory;
+				if (fileSetDir.isAbsolute()) {
+					directory = fileSetDir;
+					debug("\t[FileSet]: Use absolute Path: " + directory.getPath());
+				} else {
+					directory = new File(baseDir.getPath() + File.separatorChar + fileSet.directory);
+					debug("\t[FileSet]: Resolve relative Path: " + directory.getPath());
+				}
 
 				// warn & skip if not directory
 				if (!directory.isDirectory()) {


### PR DESCRIPTION
My pull request #1 contains compatibility problem for using absolute path in FileSets.
I fixed it.
